### PR TITLE
chore: rename Go module from dvidx to xvierd

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ flow/
 ### From Source
 
 ```bash
-git clone https://github.com/dvidx/flow-cli.git
+git clone https://github.com/xvierd/flow-cli.git
 cd flow-cli
 go build -o flow .
 ./flow --help
@@ -55,7 +55,7 @@ go build -o flow .
 ### Using go install
 
 ```bash
-go install github.com/dvidx/flow-cli@latest
+go install github.com/xvierd/flow-cli@latest
 ```
 
 ## Usage

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/services"
+	"github.com/xvierd/flow-cli/internal/services"
 )
 
 var addTags []string

--- a/cmd/break.go
+++ b/cmd/break.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/adapters/tui"
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/adapters/tui"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // breakCmd represents the break command

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/services"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/services"
 )
 
 var (

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/adapters/mcp"
+	"github.com/xvierd/flow-cli/internal/adapters/mcp"
 )
 
 // mcpCmd represents the mcp command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,13 +9,13 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/adapters/git"
-	"github.com/dvidx/flow-cli/internal/adapters/notification"
-	"github.com/dvidx/flow-cli/internal/adapters/storage"
-	"github.com/dvidx/flow-cli/internal/config"
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
-	"github.com/dvidx/flow-cli/internal/services"
+	"github.com/xvierd/flow-cli/internal/adapters/git"
+	"github.com/xvierd/flow-cli/internal/adapters/notification"
+	"github.com/xvierd/flow-cli/internal/adapters/storage"
+	"github.com/xvierd/flow-cli/internal/config"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/services"
 )
 
 var (

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/adapters/tui"
-	"github.com/dvidx/flow-cli/internal/ports"
-	"github.com/dvidx/flow-cli/internal/services"
+	"github.com/xvierd/flow-cli/internal/adapters/tui"
+	"github.com/xvierd/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/services"
 )
 
 var startTaskID string

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/adapters/tui"
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/adapters/tui"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // statusCmd represents the status command

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // stopCmd represents the stop command

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dvidx/flow-cli
+module github.com/xvierd/flow-cli
 
 go 1.24.0
 

--- a/internal/adapters/git/detector.go
+++ b/internal/adapters/git/detector.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // Detector implements the ports.GitDetector interface using go-git.

--- a/internal/adapters/mcp/mcp_server.go
+++ b/internal/adapters/mcp/mcp_server.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // Server implements the MCP server using mark3labs/mcp-go.

--- a/internal/adapters/mcp/mcp_server_test.go
+++ b/internal/adapters/mcp/mcp_server_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // mockStateProvider is a mock implementation of ports.MCPStateProvider for testing.

--- a/internal/adapters/notification/notifier.go
+++ b/internal/adapters/notification/notifier.go
@@ -4,7 +4,7 @@ package notification
 import (
 	"fmt"
 
-	"github.com/dvidx/flow-cli/internal/config"
+	"github.com/xvierd/flow-cli/internal/config"
 	"github.com/gen2brain/beeep"
 )
 

--- a/internal/adapters/storage/session_repository.go
+++ b/internal/adapters/storage/session_repository.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // sessionRepository implements ports.SessionRepository using SQLite.

--- a/internal/adapters/storage/sqlite.go
+++ b/internal/adapters/storage/sqlite.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/ports"
 	"modernc.org/sqlite"
 )
 

--- a/internal/adapters/storage/sqlite_test.go
+++ b/internal/adapters/storage/sqlite_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 func TestNewMemory(t *testing.T) {

--- a/internal/adapters/storage/task_repository.go
+++ b/internal/adapters/storage/task_repository.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 	"github.com/sahilm/fuzzy"
 )
 

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -9,8 +9,8 @@ import (
 	"github.com/charmbracelet/bubbles/progress"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // Styles for the TUI.

--- a/internal/adapters/tui/timer.go
+++ b/internal/adapters/tui/timer.go
@@ -6,8 +6,8 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // Timer implements the ports.Timer interface using Bubbletea.

--- a/internal/adapters/tui/tui_test.go
+++ b/internal/adapters/tui/tui_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 func TestFormatDuration(t *testing.T) {

--- a/internal/ports/mcp.go
+++ b/internal/ports/mcp.go
@@ -3,7 +3,7 @@ package ports
 import (
 	"context"
 
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // MCPHandler defines the interface for MCP server operations.

--- a/internal/ports/storage.go
+++ b/internal/ports/storage.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // TaskRepository defines the interface for task persistence.

--- a/internal/ports/storage_test.go
+++ b/internal/ports/storage_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // Mock implementations for testing interfaces.

--- a/internal/ports/timer.go
+++ b/internal/ports/timer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/domain"
 )
 
 // TimerView defines the interface for timer display updates.

--- a/internal/services/pomodoro_service.go
+++ b/internal/services/pomodoro_service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // PomodoroService handles pomodoro session use cases.

--- a/internal/services/pomodoro_service_test.go
+++ b/internal/services/pomodoro_service_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 func clearSessions(t *testing.T, store ports.Storage, ctx context.Context) {

--- a/internal/services/state_service.go
+++ b/internal/services/state_service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // StateService implements the MCPStateProvider interface.

--- a/internal/services/task_service.go
+++ b/internal/services/task_service.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // TaskService handles task-related use cases.

--- a/internal/services/task_service_test.go
+++ b/internal/services/task_service_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dvidx/flow-cli/internal/adapters/storage"
-	"github.com/dvidx/flow-cli/internal/domain"
-	"github.com/dvidx/flow-cli/internal/ports"
+	"github.com/xvierd/flow-cli/internal/adapters/storage"
+	"github.com/xvierd/flow-cli/internal/domain"
+	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 func setupTestStorage(t *testing.T) (ports.Storage, func()) {

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/dvidx/flow-cli/cmd"
+import "github.com/xvierd/flow-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
## Summary
- Rename Go module path from `github.com/dvidx/flow-cli` to `github.com/xvierd/flow-cli` across all 31 files
- Fixes `go install github.com/xvierd/flow-cli@latest` failing due to module path mismatch

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 7 test packages green)
- [x] `grep -r "dvidx" .` returns no stale references