### PR TITLE
feat: add install script and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+          - os: macos-latest
+            goos: darwin
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: 0
+        run: |
+          go build -ldflags="-s -w" -o flow .
+          tar czf flow-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz flow
+      - uses: actions/upload-artifact@v4
+        with:
+          name: flow-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: flow-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: "*.tar.gz"

--- a/README.md
+++ b/README.md
@@ -39,9 +39,21 @@ flow/
 
 ## Installation
 
-### Prerequisites
+### Quick Install
 
-- Go 1.23 or later
+```bash
+curl -sSL https://raw.githubusercontent.com/xvierd/flow-cli/main/install.sh | sh
+```
+
+This downloads the latest release binary and installs it to `/usr/local/bin/flow`.
+
+### Using go install
+
+```bash
+go install github.com/xvierd/flow-cli@latest
+```
+
+> **Note:** Make sure `$(go env GOPATH)/bin` is in your `PATH`. The binary will be named `flow-cli`.
 
 ### From Source
 
@@ -50,12 +62,6 @@ git clone https://github.com/xvierd/flow-cli.git
 cd flow-cli
 go build -o flow .
 ./flow --help
-```
-
-### Using go install
-
-```bash
-go install github.com/xvierd/flow-cli@latest
 ```
 
 ## Usage

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+REPO="xvierd/flow-cli"
+BINARY="flow"
+INSTALL_DIR="/usr/local/bin"
+
+# Detect OS
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$OS" in
+  linux)  OS="linux" ;;
+  darwin) OS="darwin" ;;
+  *) echo "Unsupported OS: $OS" && exit 1 ;;
+esac
+
+# Detect architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64)  ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: $ARCH" && exit 1 ;;
+esac
+
+# Get latest version
+VERSION=$(curl -sSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+if [ -z "$VERSION" ]; then
+  echo "Error: could not determine latest version"
+  exit 1
+fi
+
+echo "Installing ${BINARY} ${VERSION} (${OS}/${ARCH})..."
+
+# Download and install
+TARBALL="${BINARY}-${OS}-${ARCH}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -sSL "$URL" -o "${TMPDIR}/${TARBALL}"
+tar xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR"
+
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+else
+  echo "Need sudo to install to ${INSTALL_DIR}"
+  sudo mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+fi
+
+chmod +x "${INSTALL_DIR}/${BINARY}"
+
+echo "${BINARY} ${VERSION} installed to ${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
## Summary
- Add `install.sh` for one-line installs: `curl -sSL .../install.sh | sh`
- Add GitHub Actions release workflow that builds binaries for linux/darwin (amd64/arm64) on tag push
- Update README with quick install instructions

## How it works
1. On `git tag v*` + push, the workflow builds cross-platform binaries and creates a GitHub Release
2. `install.sh` detects OS/arch, fetches the latest release, and installs to `/usr/local/bin/flow`

## Test plan
- [ ] Merge, then tag `v0.2.0` and push to trigger the release workflow
- [ ] Verify binaries appear on the GitHub Release page
- [ ] Run `curl -sSL .../install.sh | sh` and confirm `flow` works