### PR TITLE
fix: ensure go install produces binary named flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
         run: |
-          go build -ldflags="-s -w" -o flow .
+          go build -ldflags="-s -w" -o flow ./cmd/flow
           tar czf flow-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz flow
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ This downloads the latest release binary and installs it to `/usr/local/bin/flow
 ### Using go install
 
 ```bash
-go install github.com/xvierd/flow-cli@latest
+go install github.com/xvierd/flow-cli/cmd/flow@latest
 ```
 
-> **Note:** Make sure `$(go env GOPATH)/bin` is in your `PATH`. The binary will be named `flow-cli`.
+> **Note:** Make sure `$(go env GOPATH)/bin` is in your `PATH`.
 
 ### From Source
 
 ```bash
 git clone https://github.com/xvierd/flow-cli.git
 cd flow-cli
-go build -o flow .
+go build -o flow ./cmd/flow
 ./flow --help
 ```
 

--- a/cmd/flow/main.go
+++ b/cmd/flow/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/xvierd/flow-cli/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
- Add `cmd/flow/main.go` entry point so `go install .../cmd/flow@latest` produces a binary named `flow` (not `flow-cli`)
- Update release workflow to build from `./cmd/flow`
- Update README install instructions

## Before
`go install github.com/xvierd/flow-cli@latest` → binary named `flow-cli`

## After
`go install github.com/xvierd/flow-cli/cmd/flow@latest` → binary named `flow`

## Test plan
- [x] `go build ./cmd/flow` produces `flow` binary
- [x] `go build ./...` passes
- [x] `go test ./...` passes