### PR TITLE
fix: clean up error output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,8 @@ var rootCmd = &cobra.Command{
 	Short: "Flow - A Pomodoro CLI timer with task tracking",
 	Long: `Flow is a command-line Pomodoro timer that helps you stay focused
 and track your work sessions with optional git integration.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return initializeServices()
 	},


### PR DESCRIPTION
## Summary
- Add `SilenceUsage` and `SilenceErrors` to root cobra command
- Errors now show a single clean line instead of dumping usage text

## Before
```
Error: failed to start pomodoro: session already active
Usage:
        flow start [task-id] [flags]

Flags:
        -h, --help          help for start
...
Error: failed to start pomodoro: session already active
```

## After
```
Error: failed to start pomodoro: session already active
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Error output verified clean