### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Binary
+flow
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Test/build
+*.test
+*.out
+coverage.txt


### PR DESCRIPTION
## Summary
- Add `.gitignore` to keep build artifacts, IDE files, and OS files out of the repo