### PR TITLE
fix: terminal prompt not reading Enter key

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -58,8 +57,8 @@ an active task, that task will be used.`,
 			fmt.Printf("   Session ID: %s\n", active.ID[:8])
 			fmt.Print("Do you want to stop it and start a new one? [y/N] ")
 
-			reader := bufio.NewReader(os.Stdin)
-			answer, _ := reader.ReadString('\n')
+			var answer string
+			fmt.Scanln(&answer)
 			answer = strings.TrimSpace(strings.ToLower(answer))
 
 			if answer != "y" && answer != "yes" {


### PR DESCRIPTION
## Summary
- Replace `bufio.ReadString('\n')` with `fmt.Scanln` for the session conflict prompt
- `ReadString('\n')` waited for `\n` but the terminal sends `\r` on Enter, causing input to hang and show `^M` characters

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `flow start` twice, type `y` + Enter at prompt — should stop old session and start new one