### PR TITLE
fix: unfreeze TUI by making state refresh async

### DIFF
--- a/cmd/break.go
+++ b/cmd/break.go
@@ -40,11 +40,9 @@ var breakCmd = &cobra.Command{
 		ctx = setupSignalHandler()
 		timer := tui.NewTimer()
 		
-		timer.SetUpdateCallback(func() {
+		timer.SetFetchState(func() *domain.CurrentState {
 			newState, _ := stateService.GetCurrentState(ctx)
-			if newState != nil {
-				timer.UpdateState(newState)
-			}
+			return newState
 		})
 
 		timer.SetCommandCallback(func(cmd ports.TimerCommand) {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -99,12 +99,10 @@ an active task, that task will be used.`,
 		ctx = setupSignalHandler()
 		timer := tui.NewTimer()
 		
-		// Set up update callback to refresh state
-		timer.SetUpdateCallback(func() {
+		// Set up async state fetcher for TUI refresh
+		timer.SetFetchState(func() *domain.CurrentState {
 			newState, _ := stateService.GetCurrentState(ctx)
-			if newState != nil {
-				timer.UpdateState(newState)
-			}
+			return newState
 		})
 
 		// Set up command callback to handle timer commands

--- a/internal/adapters/tui/timer.go
+++ b/internal/adapters/tui/timer.go
@@ -13,7 +13,7 @@ import (
 // Timer implements the ports.Timer interface using Bubbletea.
 type Timer struct {
 	program         *tea.Program
-	updateCallback  func()
+	fetchState      func() *domain.CurrentState
 	commandCallback func(ports.TimerCommand)
 }
 
@@ -25,7 +25,7 @@ func NewTimer() ports.Timer {
 // Run starts the timer interface and blocks until completion.
 func (t *Timer) Run(ctx context.Context, initialState *domain.CurrentState) error {
 	model := NewModel(initialState)
-	model.updateCallback = t.updateCallback
+	model.fetchState = t.fetchState
 	model.commandCallback = t.commandCallback
 
 	t.program = tea.NewProgram(
@@ -57,9 +57,9 @@ func (t *Timer) Stop() {
 	}
 }
 
-// SetUpdateCallback sets a function to call on timer updates.
-func (t *Timer) SetUpdateCallback(callback func()) {
-	t.updateCallback = callback
+// SetFetchState sets a function that returns the current state.
+func (t *Timer) SetFetchState(fetch func() *domain.CurrentState) {
+	t.fetchState = fetch
 }
 
 // SetCommandCallback sets a function to call when commands are received.

--- a/internal/ports/timer.go
+++ b/internal/ports/timer.go
@@ -65,8 +65,9 @@ type Timer interface {
 	// Stop gracefully stops the timer interface.
 	Stop()
 
-	// SetUpdateCallback sets a function to call on timer updates.
-	SetUpdateCallback(callback func())
+	// SetFetchState sets a function that returns the current application state.
+	// This is called asynchronously on each tick to refresh the TUI.
+	SetFetchState(fetch func() *domain.CurrentState)
 
 	// SetCommandCallback sets a function to call when commands are received.
 	SetCommandCallback(callback func(cmd TimerCommand))


### PR DESCRIPTION
## Summary
- State fetching (database query) was running synchronously inside Bubbletea's `Update`, blocking the entire UI
- Replace `SetUpdateCallback` with `SetFetchState` that runs via async `tea.Cmd`
- Timer, progress bar, and keyboard shortcuts now stay responsive

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `flow start` shows live-updating timer and progress bar
- [ ] Manual: keyboard shortcuts respond immediately