### PR TITLE
feat: add stop key to TUI

### DIFF
--- a/cmd/break.go
+++ b/cmd/break.go
@@ -51,6 +51,8 @@ var breakCmd = &cobra.Command{
 				_, _ = pomodoroSvc.PauseSession(ctx)
 			case ports.CmdResume:
 				_, _ = pomodoroSvc.ResumeSession(ctx)
+			case ports.CmdStop:
+				_, _ = pomodoroSvc.StopSession(ctx)
 			case ports.CmdCancel:
 				_ = pomodoroSvc.CancelSession(ctx)
 			}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -112,6 +112,8 @@ an active task, that task will be used.`,
 				_, _ = pomodoroSvc.PauseSession(ctx)
 			case ports.CmdResume:
 				_, _ = pomodoroSvc.ResumeSession(ctx)
+			case ports.CmdStop:
+				_, _ = pomodoroSvc.StopSession(ctx)
 			case ports.CmdCancel:
 				_ = pomodoroSvc.CancelSession(ctx)
 			case ports.CmdBreak:

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -101,6 +101,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.commandCallback != nil {
 				m.commandCallback(ports.CmdBreak)
 			}
+		case "x":
+			if m.commandCallback != nil {
+				m.commandCallback(ports.CmdStop)
+			}
+			return m, tea.Quit
 		}
 
 	case tea.WindowSizeMsg:
@@ -190,7 +195,7 @@ func (m Model) View() string {
 
 	// Help
 	sections = append(sections, "")
-	sections = append(sections, helpStyle.Render("[s]tart [p]ause [c]ancel [b]reak [q]uit"))
+	sections = append(sections, helpStyle.Render("[s]tart [p]ause [x] stop [c]ancel [b]reak [q]uit"))
 
 	return lipgloss.JoinVertical(lipgloss.Center, sections...)
 }

--- a/internal/ports/timer.go
+++ b/internal/ports/timer.go
@@ -52,6 +52,9 @@ const (
 	// CmdBreak starts a break session.
 	CmdBreak TimerCommand = "break"
 
+	// CmdStop completes the current session.
+	CmdStop TimerCommand = "stop"
+
 	// CmdQuit exits the application.
 	CmdQuit TimerCommand = "quit"
 )


### PR DESCRIPTION
## Summary
- Add `x` key to stop (complete) the current session from within the TUI
- Previously the only options were cancel or quit

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: press `x` during a session — completes it and exits