### PR TITLE
feat: wizard flow and expired session auto-complete

### DIFF
--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -123,6 +123,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case stateMsg:
 		if msg.state != nil {
 			m.state = msg.state
+			// Session was auto-completed by GetCurrentState (timer expired)
+			if m.state.ActiveSession == nil {
+				// No active session means it was completed - stay open to show stats
+			}
 		}
 
 	case *domain.CurrentState:

--- a/internal/services/state_service.go
+++ b/internal/services/state_service.go
@@ -36,6 +36,13 @@ func (s *StateService) GetCurrentState(ctx context.Context) (*domain.CurrentStat
 	activeTask, _ := s.storage.Tasks().FindActive(ctx)
 	activeSession, _ := s.storage.Sessions().FindActive(ctx)
 
+	// Auto-complete expired sessions that are still marked as running
+	if activeSession != nil && activeSession.Status == domain.SessionStatusRunning && activeSession.RemainingTime() == 0 {
+		activeSession.Complete()
+		_ = s.storage.Sessions().Update(ctx, activeSession)
+		activeSession = nil
+	}
+
 	todayStats, err := s.storage.Sessions().GetDailyStats(ctx, time.Now())
 	if err != nil {
 		todayStats = &domain.DailyStats{}


### PR DESCRIPTION
## Summary
- Bare `flow` command now launches an interactive wizard (task name + duration prompts) for zero-friction session start
- Fix bug where expired sessions stayed "running" in the DB, causing status line to show 00:00 forever
- Refactor TUI launch into shared `launchTUI` function, removing duplication between wizard and `flow start`

## Test plan
- [ ] Run `flow` with no args, verify wizard prompts appear
- [ ] Press Enter through both prompts, verify 25m session starts
- [ ] Enter a task name and custom duration, verify both are applied
- [ ] Let a session expire, run `flow status --json`, verify `active_session` is null
- [ ] Verify status line script shows no timer after session expires