### PR TITLE
feat: comprehensive TUI completion experience

### DIFF
--- a/cmd/break.go
+++ b/cmd/break.go
@@ -6,9 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/xvierd/flow-cli/internal/adapters/tui"
 	"github.com/xvierd/flow-cli/internal/domain"
-	"github.com/xvierd/flow-cli/internal/ports"
 )
 
 // breakCmd represents the break command
@@ -26,8 +24,8 @@ var breakCmd = &cobra.Command{
 			return fmt.Errorf("failed to start break: %w", err)
 		}
 
-		fmt.Printf("☕ Break started! Duration: %s (%s)\n", 
-			session.Duration, 
+		fmt.Printf("☕ Break started! Duration: %s (%s)\n",
+			session.Duration,
 			getBreakTypeLabel(session.Type))
 
 		// Get the current state for the TUI
@@ -36,33 +34,7 @@ var breakCmd = &cobra.Command{
 			return fmt.Errorf("failed to get current state: %w", err)
 		}
 
-		// Run the TUI timer
-		ctx = setupSignalHandler()
-		timer := tui.NewTimer()
-		
-		timer.SetFetchState(func() *domain.CurrentState {
-			newState, _ := stateService.GetCurrentState(ctx)
-			return newState
-		})
-
-		timer.SetCommandCallback(func(cmd ports.TimerCommand) {
-			switch cmd {
-			case ports.CmdPause:
-				_, _ = pomodoroSvc.PauseSession(ctx)
-			case ports.CmdResume:
-				_, _ = pomodoroSvc.ResumeSession(ctx)
-			case ports.CmdStop:
-				_, _ = pomodoroSvc.StopSession(ctx)
-			case ports.CmdCancel:
-				_ = pomodoroSvc.CancelSession(ctx)
-			}
-		})
-
-		if err := timer.Run(ctx, state); err != nil {
-			return fmt.Errorf("timer error: %w", err)
-		}
-
-		return nil
+		return launchTUI(ctx, state, workingDir)
 	},
 }
 

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -44,20 +44,25 @@ type stateMsg struct {
 
 // Model represents the TUI state.
 type Model struct {
-	state           *domain.CurrentState
-	progress        progress.Model
-	width           int
-	height          int
-	completed       bool
-	fetchState      func() *domain.CurrentState
-	commandCallback func(ports.TimerCommand)
+	state                *domain.CurrentState
+	progress             progress.Model
+	width                int
+	height               int
+	completed            bool
+	completedSessionType domain.SessionType
+	notified             bool
+	fetchState           func() *domain.CurrentState
+	commandCallback      func(ports.TimerCommand)
+	onSessionComplete    func(domain.SessionType)
+	completionInfo       *domain.CompletionInfo
 }
 
 // NewModel creates a new TUI model.
-func NewModel(initialState *domain.CurrentState) Model {
+func NewModel(initialState *domain.CurrentState, info *domain.CompletionInfo) Model {
 	return Model{
-		state:    initialState,
-		progress: progress.New(progress.WithDefaultGradient()),
+		state:          initialState,
+		progress:       progress.New(progress.WithDefaultGradient()),
+		completionInfo: info,
 	}
 }
 
@@ -82,8 +87,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c":
 			return m, tea.Quit
 		case "s":
-			if m.commandCallback != nil {
-				m.commandCallback(ports.CmdStart)
+			if m.completed && m.completedSessionType != domain.SessionTypeWork {
+				// Break just finished — start a new work session
+				if m.commandCallback != nil {
+					m.commandCallback(ports.CmdStart)
+					m.completed = false
+					m.notified = false
+				}
 			}
 		case "p":
 			if m.commandCallback != nil && m.state.ActiveSession != nil {
@@ -99,9 +109,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Quit
 		case "b":
-			if m.commandCallback != nil {
-				m.commandCallback(ports.CmdBreak)
-				m.completed = false
+			if m.completed && m.completedSessionType == domain.SessionTypeWork {
+				// Work just finished — start a break
+				if m.commandCallback != nil {
+					m.commandCallback(ports.CmdBreak)
+					m.completed = false
+					m.notified = false
+				}
 			}
 		case "x":
 			if m.commandCallback != nil {
@@ -126,8 +140,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.state != nil {
 			// Detect session completion: had a session before, now it's gone
 			if m.state.ActiveSession != nil && msg.state.ActiveSession == nil {
+				m.completedSessionType = m.state.ActiveSession.Type
 				m.completed = true
+
+				// Fire notification callback once
+				if !m.notified && m.onSessionComplete != nil {
+					m.onSessionComplete(m.completedSessionType)
+					m.notified = true
+				}
 			}
+
+			// Detect new session started → reset completed state
+			if m.completed && msg.state.ActiveSession != nil {
+				m.completed = false
+				m.notified = false
+			}
+
 			m.state = msg.state
 		}
 
@@ -161,59 +189,13 @@ func (m Model) View() string {
 	}
 
 	if m.completed {
-		// Session completed screen
-		sections = append(sections, statusStyle.Render("Session complete!"))
-		sections = append(sections, "")
-		sections = append(sections, m.progress.ViewAs(1.0))
-
-		// Daily stats
-		stats := m.state.TodayStats
-		statsText := fmt.Sprintf("📊 Today: %d work sessions, %d breaks, %s worked",
-			stats.WorkSessions, stats.BreaksTaken, formatDuration(stats.TotalWorkTime))
-		sections = append(sections, "")
-		sections = append(sections, helpStyle.Render(statsText))
-
-		// Help
-		sections = append(sections, "")
-		sections = append(sections, helpStyle.Render("[b]reak [q]uit"))
-	} else if m.state.ActiveSession != nil {
-		session := m.state.ActiveSession
-
-		// Session type and status
-		statusText := fmt.Sprintf("Status: %s (%s)",
-			domain.GetSessionTypeLabel(session.Type),
-			domain.GetStatusLabel(session.Status))
-		sections = append(sections, statusStyle.Render(statusText))
-
-		// Timer
-		remaining := session.RemainingTime()
-		timeText := formatDuration(remaining)
-		sections = append(sections, timeStyle.Render(timeText))
-
-		// Progress bar
-		prog := session.Progress()
-		sections = append(sections, m.progress.ViewAs(prog))
-
-		// Git context
-		if session.GitBranch != "" {
-			commitShort := session.GitCommit
-			if len(commitShort) > 7 {
-				commitShort = commitShort[:7]
-			}
-			gitInfo := fmt.Sprintf("🌿 %s (%s)", session.GitBranch, commitShort)
-			sections = append(sections, helpStyle.Render(gitInfo))
+		if m.completedSessionType == domain.SessionTypeWork {
+			sections = m.viewWorkComplete(sections)
+		} else {
+			sections = m.viewBreakComplete(sections)
 		}
-
-		// Daily stats
-		stats := m.state.TodayStats
-		statsText := fmt.Sprintf("📊 Today: %d work sessions, %d breaks, %s worked",
-			stats.WorkSessions, stats.BreaksTaken, formatDuration(stats.TotalWorkTime))
-		sections = append(sections, "")
-		sections = append(sections, helpStyle.Render(statsText))
-
-		// Help
-		sections = append(sections, "")
-		sections = append(sections, helpStyle.Render("[s]tart [p]ause [x] stop [c]ancel [b]reak [q]uit"))
+	} else if m.state.ActiveSession != nil {
+		sections = m.viewActiveSession(sections)
 	} else {
 		sections = append(sections, statusStyle.Render("No active session"))
 		sections = append(sections, "")
@@ -221,6 +203,101 @@ func (m Model) View() string {
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Center, sections...)
+}
+
+func (m Model) viewWorkComplete(sections []string) []string {
+	sections = append(sections, "")
+	sections = append(sections, statusStyle.Render("Session complete! Great work."))
+	sections = append(sections, m.progress.ViewAs(1.0))
+
+	// Show break info
+	if m.completionInfo != nil {
+		breakLabel := domain.GetSessionTypeLabel(m.completionInfo.NextBreakType)
+		breakDur := formatDuration(m.completionInfo.NextBreakDuration)
+
+		breakLine := fmt.Sprintf("[b] %s %s", breakDur, breakLabel)
+		if m.completionInfo.NextBreakType == domain.SessionTypeLongBreak {
+			breakLine += " - you earned it!"
+		}
+		sections = append(sections, "")
+		sections = append(sections, statusStyle.Render(breakLine))
+
+		if m.completionInfo.NextBreakType == domain.SessionTypeShortBreak {
+			countLine := fmt.Sprintf("%d of %d sessions until long break",
+				m.completionInfo.SessionsBeforeLong-m.completionInfo.SessionsUntilLong,
+				m.completionInfo.SessionsBeforeLong)
+			sections = append(sections, helpStyle.Render(countLine))
+		}
+	}
+
+	// Daily stats
+	stats := m.state.TodayStats
+	statsText := fmt.Sprintf("📊 Today: %d work sessions, %d breaks, %s worked",
+		stats.WorkSessions, stats.BreaksTaken, formatDuration(stats.TotalWorkTime))
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render(statsText))
+
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render("[b]reak  [q]uit"))
+	return sections
+}
+
+func (m Model) viewBreakComplete(sections []string) []string {
+	sections = append(sections, "")
+	sections = append(sections, statusStyle.Render("Break over! Ready to focus?"))
+	sections = append(sections, m.progress.ViewAs(1.0))
+
+	// Daily stats
+	stats := m.state.TodayStats
+	statsText := fmt.Sprintf("📊 Today: %d work sessions, %d breaks, %s worked",
+		stats.WorkSessions, stats.BreaksTaken, formatDuration(stats.TotalWorkTime))
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render(statsText))
+
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render("[s]tart new session  [q]uit"))
+	return sections
+}
+
+func (m Model) viewActiveSession(sections []string) []string {
+	session := m.state.ActiveSession
+
+	// Session type and status
+	statusText := fmt.Sprintf("Status: %s (%s)",
+		domain.GetSessionTypeLabel(session.Type),
+		domain.GetStatusLabel(session.Status))
+	sections = append(sections, statusStyle.Render(statusText))
+
+	// Timer
+	remaining := session.RemainingTime()
+	timeText := formatDuration(remaining)
+	sections = append(sections, timeStyle.Render(timeText))
+
+	// Progress bar
+	prog := session.Progress()
+	sections = append(sections, m.progress.ViewAs(prog))
+
+	// Git context
+	if session.GitBranch != "" {
+		commitShort := session.GitCommit
+		if len(commitShort) > 7 {
+			commitShort = commitShort[:7]
+		}
+		gitInfo := fmt.Sprintf("🌿 %s (%s)", session.GitBranch, commitShort)
+		sections = append(sections, helpStyle.Render(gitInfo))
+	}
+
+	// Daily stats
+	stats := m.state.TodayStats
+	statsText := fmt.Sprintf("📊 Today: %d work sessions, %d breaks, %s worked",
+		stats.WorkSessions, stats.BreaksTaken, formatDuration(stats.TotalWorkTime))
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render(statsText))
+
+	// Help
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render("[s]tart [p]ause [x] stop [c]ancel [b]reak [q]uit"))
+	return sections
 }
 
 // tickCmd creates a command that sends a tick message.

--- a/internal/adapters/tui/tui_test.go
+++ b/internal/adapters/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestFormatDuration(t *testing.T) {
 
 func TestNewModel(t *testing.T) {
 	state := &domain.CurrentState{}
-	model := NewModel(state)
+	model := NewModel(state, nil)
 
 	if model.state != state {
 		t.Error("NewModel() should store the initial state")
@@ -51,13 +52,13 @@ func TestModel_View(t *testing.T) {
 		ActiveTask:    task,
 		ActiveSession: session,
 		TodayStats: domain.DailyStats{
-			WorkSessions: 2,
-			BreaksTaken:  1,
+			WorkSessions:  2,
+			BreaksTaken:   1,
 			TotalWorkTime: 50 * time.Minute,
 		},
 	}
 
-	model := NewModel(state)
+	model := NewModel(state, nil)
 	model.width = 80
 	model.height = 24
 
@@ -78,7 +79,7 @@ func TestModel_View_NoActiveSession(t *testing.T) {
 		TodayStats:    domain.DailyStats{},
 	}
 
-	model := NewModel(state)
+	model := NewModel(state, nil)
 	model.width = 80
 	model.height = 24
 
@@ -86,5 +87,103 @@ func TestModel_View_NoActiveSession(t *testing.T) {
 
 	if view == "" {
 		t.Error("View() should not return empty string")
+	}
+}
+
+func TestModel_View_WorkComplete(t *testing.T) {
+	state := &domain.CurrentState{
+		TodayStats: domain.DailyStats{
+			WorkSessions:  3,
+			BreaksTaken:   2,
+			TotalWorkTime: 75 * time.Minute,
+		},
+	}
+
+	info := &domain.CompletionInfo{
+		NextBreakType:      domain.SessionTypeShortBreak,
+		NextBreakDuration:  5 * time.Minute,
+		SessionsUntilLong:  1,
+		SessionsBeforeLong: 4,
+	}
+
+	model := NewModel(state, info)
+	model.width = 80
+	model.height = 24
+	model.completed = true
+	model.completedSessionType = domain.SessionTypeWork
+
+	view := model.View()
+
+	if !strings.Contains(view, "Session complete") {
+		t.Error("Work-complete view should contain 'Session complete'")
+	}
+	if !strings.Contains(view, "05:00") {
+		t.Error("Work-complete view should show break duration '05:00'")
+	}
+	if !strings.Contains(view, "Short Break") {
+		t.Error("Work-complete view should show 'Short Break'")
+	}
+	if !strings.Contains(view, "3 of 4 sessions until long break") {
+		t.Error("Work-complete view should show session count info")
+	}
+	if !strings.Contains(view, "[b]reak") {
+		t.Error("Work-complete view should show [b]reak option")
+	}
+}
+
+func TestModel_View_WorkComplete_LongBreak(t *testing.T) {
+	state := &domain.CurrentState{
+		TodayStats: domain.DailyStats{
+			WorkSessions:  4,
+			BreaksTaken:   3,
+			TotalWorkTime: 100 * time.Minute,
+		},
+	}
+
+	info := &domain.CompletionInfo{
+		NextBreakType:      domain.SessionTypeLongBreak,
+		NextBreakDuration:  15 * time.Minute,
+		SessionsUntilLong:  0,
+		SessionsBeforeLong: 4,
+	}
+
+	model := NewModel(state, info)
+	model.width = 80
+	model.height = 24
+	model.completed = true
+	model.completedSessionType = domain.SessionTypeWork
+
+	view := model.View()
+
+	if !strings.Contains(view, "you earned it") {
+		t.Error("Long break view should contain 'you earned it'")
+	}
+	if !strings.Contains(view, "15:00") {
+		t.Error("Long break view should show '15:00' duration")
+	}
+}
+
+func TestModel_View_BreakComplete(t *testing.T) {
+	state := &domain.CurrentState{
+		TodayStats: domain.DailyStats{
+			WorkSessions:  3,
+			BreaksTaken:   3,
+			TotalWorkTime: 75 * time.Minute,
+		},
+	}
+
+	model := NewModel(state, nil)
+	model.width = 80
+	model.height = 24
+	model.completed = true
+	model.completedSessionType = domain.SessionTypeShortBreak
+
+	view := model.View()
+
+	if !strings.Contains(view, "Break over") {
+		t.Error("Break-complete view should contain 'Break over'")
+	}
+	if !strings.Contains(view, "[s]tart") {
+		t.Error("Break-complete view should show [s]tart option")
 	}
 }

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -20,6 +20,15 @@ type DailyStats struct {
 	TasksCompleted    int
 }
 
+// CompletionInfo holds pre-computed context about what break comes next
+// after a work session completes, or signals that a break just ended.
+type CompletionInfo struct {
+	NextBreakType      SessionType
+	NextBreakDuration  time.Duration
+	SessionsUntilLong  int
+	SessionsBeforeLong int
+}
+
 // StateSnapshot captures the complete system state at a point in time.
 type StateSnapshot struct {
 	Timestamp     time.Time

--- a/internal/ports/timer.go
+++ b/internal/ports/timer.go
@@ -75,6 +75,12 @@ type Timer interface {
 	// SetCommandCallback sets a function to call when commands are received.
 	SetCommandCallback(callback func(cmd TimerCommand))
 
+	// SetOnSessionComplete sets a callback fired when a session naturally completes.
+	SetOnSessionComplete(callback func(domain.SessionType))
+
+	// SetCompletionInfo sets pre-computed break context for the completion screen.
+	SetCompletionInfo(info *domain.CompletionInfo)
+
 	// UpdateState updates the displayed state.
 	UpdateState(state *domain.CurrentState)
 }


### PR DESCRIPTION
## Summary
- Redesign timer completion screen to show break type, duration, and session progress when a work session expires
- Add break-complete screen with `[s]tart new session` prompt when a break ends
- Fire desktop notifications on natural timer expiry (work and break sessions)
- Wire `CmdStart` in command callback so `s` key works from break-complete screen
- Refactor `break.go` to reuse shared `launchTUI` instead of duplicating TUI setup
- Add `CompletionInfo` domain type and extend `Timer` port interface with `SetOnSessionComplete` and `SetCompletionInfo`

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./... -count=1` all tests pass
- [x] `go vet ./...` no warnings
- [ ] Manual: run `flow`, let timer expire → see work-complete screen with break info
- [ ] Manual: press `b` → break starts, let it expire → see break-complete screen
- [ ] Manual: press `s` → new work session starts
- [ ] Manual: verify desktop notification fires on both completions