### PR TITLE
feat: skip break option and config hint

### DIFF
--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -87,13 +87,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c":
 			return m, tea.Quit
 		case "s":
-			if m.completed && m.completedSessionType != domain.SessionTypeWork {
-				// Break just finished — start a new work session
-				if m.commandCallback != nil {
-					m.commandCallback(ports.CmdStart)
-					m.completed = false
-					m.notified = false
-				}
+			if m.completed && m.commandCallback != nil {
+				// Start a new work session (skip break or resume after break)
+				m.commandCallback(ports.CmdStart)
+				m.completed = false
+				m.notified = false
 			}
 		case "p":
 			if m.commandCallback != nil && m.state.ActiveSession != nil {
@@ -238,7 +236,9 @@ func (m Model) viewWorkComplete(sections []string) []string {
 	sections = append(sections, helpStyle.Render(statsText))
 
 	sections = append(sections, "")
-	sections = append(sections, helpStyle.Render("[b]reak  [q]uit"))
+	sections = append(sections, helpStyle.Render("[b]reak  [s]kip  [q]uit"))
+	sections = append(sections, "")
+	sections = append(sections, helpStyle.Render("Customize durations in ~/.flow/config.toml"))
 	return sections
 }
 

--- a/internal/adapters/tui/tui_test.go
+++ b/internal/adapters/tui/tui_test.go
@@ -129,6 +129,9 @@ func TestModel_View_WorkComplete(t *testing.T) {
 	if !strings.Contains(view, "[b]reak") {
 		t.Error("Work-complete view should show [b]reak option")
 	}
+	if !strings.Contains(view, "[s]kip") {
+		t.Error("Work-complete view should show [s]kip option")
+	}
 }
 
 func TestModel_View_WorkComplete_LongBreak(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `[s]kip` option on the work-complete screen to start a new work session without taking a break
- Show a hint pointing to `~/.flow/config.toml` for customizing durations

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./... -count=1` all tests pass
- [ ] Manual: let timer expire, press `s` to skip break and start new session
- [ ] Manual: verify config hint is visible on completion screen