### PR TITLE
fix: stop active session before starting break

### DIFF
--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -113,6 +113,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else if !m.completed && m.state.ActiveSession != nil {
 				if m.confirmBreak {
 					if m.commandCallback != nil {
+						// Stop the active session first, then start break
+						m.commandCallback(ports.CmdStop)
 						m.commandCallback(ports.CmdBreak)
 						m.completed = false
 						m.notified = false


### PR DESCRIPTION
## Summary
- When user confirms break mid-session (presses `b` twice), the break failed silently because `StartBreak()` returns `ErrSessionAlreadyActive`
- Now calls `CmdStop` before `CmdBreak` to properly stop the running session first