### PR TITLE
fix: resolve all lint errors and remove Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,19 +94,3 @@ jobs:
     
     - name: Test on macOS
       run: go test -race -v ./...
-
-  build-windows:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.24'
-    
-    - name: Build on Windows
-      run: go build -v ./...
-    
-    - name: Test on Windows
-      run: go test -race -v ./...

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -36,7 +36,7 @@ func TestAddCmd(t *testing.T) {
 	t.Run("add command has tags flag", func(t *testing.T) {
 		flag := addCmd.Flags().Lookup("tags")
 		if flag == nil {
-			t.Error("addCmd should have --tags flag")
+			t.Fatal("addCmd should have --tags flag")
 		}
 		if flag.Shorthand != "t" {
 			t.Errorf("tags flag shorthand = %q, want %q", flag.Shorthand, "t")

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -16,7 +16,7 @@ func TestListCmd(t *testing.T) {
 	t.Run("list command has status flag", func(t *testing.T) {
 		flag := listCmd.Flags().Lookup("status")
 		if flag == nil {
-			t.Error("listCmd should have --status flag")
+			t.Fatal("listCmd should have --status flag")
 		}
 		if flag.Shorthand != "s" {
 			t.Errorf("status flag shorthand = %q, want %q", flag.Shorthand, "s")
@@ -26,7 +26,7 @@ func TestListCmd(t *testing.T) {
 	t.Run("list command has all flag", func(t *testing.T) {
 		flag := listCmd.Flags().Lookup("all")
 		if flag == nil {
-			t.Error("listCmd should have --all flag")
+			t.Fatal("listCmd should have --all flag")
 		}
 		if flag.Shorthand != "a" {
 			t.Errorf("all flag shorthand = %q, want %q", flag.Shorthand, "a")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -56,7 +56,7 @@ an active task, that task will be used.`,
 			fmt.Print("Do you want to stop it and start a new one? [y/N] ")
 
 			var answer string
-			fmt.Scanln(&answer)
+			_, _ = fmt.Scanln(&answer)
 			answer = strings.TrimSpace(strings.ToLower(answer))
 
 			if answer != "y" && answer != "yes" {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -26,7 +26,7 @@ var stopCmd = &cobra.Command{
 		if !jsonOutput {
 			fmt.Print("Add session notes (optional, press Enter to skip): ")
 			var notes string
-			fmt.Scanln(&notes)
+			_, _ = fmt.Scanln(&notes)
 			if notes != "" {
 				session, _ = pomodoroSvc.AddSessionNotes(ctx, session.ID, notes)
 			}
@@ -34,7 +34,7 @@ var stopCmd = &cobra.Command{
 
 		// Send notification if enabled
 		if notifier != nil && notifier.IsEnabled() {
-			notifier.NotifyPomodoroComplete(session.Duration.String())
+			_ = notifier.NotifyPomodoroComplete(session.Duration.String())
 		}
 
 		if jsonOutput {

--- a/internal/adapters/storage/sqlite.go
+++ b/internal/adapters/storage/sqlite.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/xvierd/flow-cli/internal/ports"
-	"modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 )
 
 // sqliteStorage implements the ports.Storage interface using SQLite.
@@ -111,13 +111,4 @@ func (s *sqliteStorage) Migrate() error {
 	}
 
 	return nil
-}
-
-// isUniqueConstraintError checks if an error is a unique constraint violation.
-func isUniqueConstraintError(err error) bool {
-	if err == nil {
-		return false
-	}
-	sqliteErr, ok := err.(*sqlite.Error)
-	return ok && sqliteErr.Code() == 2067 // SQLITE_CONSTRAINT_UNIQUE
 }

--- a/internal/adapters/storage/sqlite_test.go
+++ b/internal/adapters/storage/sqlite_test.go
@@ -78,9 +78,9 @@ func TestTaskRepository_FindAll(t *testing.T) {
 	task3, _ := domain.NewTask("Task 3")
 	task3.Complete()
 
-	repo.Save(ctx, task1)
-	repo.Save(ctx, task2)
-	repo.Save(ctx, task3)
+	_ = repo.Save(ctx, task1)
+	_ = repo.Save(ctx, task2)
+	_ = repo.Save(ctx, task3)
 
 	t.Run("find all without filter", func(t *testing.T) {
 		tasks, err := repo.FindAll(ctx, nil)
@@ -117,9 +117,9 @@ func TestTaskRepository_FindPending(t *testing.T) {
 	task3, _ := domain.NewTask("Completed Task")
 	task3.Complete()
 
-	repo.Save(ctx, task1)
-	repo.Save(ctx, task2)
-	repo.Save(ctx, task3)
+	_ = repo.Save(ctx, task1)
+	_ = repo.Save(ctx, task2)
+	_ = repo.Save(ctx, task3)
 
 	tasks, err := repo.FindPending(ctx)
 	if err != nil {

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -89,7 +89,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "s":
 			if m.completed && m.commandCallback != nil {
-				m.commandCallback(ports.CmdStart)
+				_ = m.commandCallback(ports.CmdStart)
 				m.completed = false
 				m.notified = false
 				m.confirmBreak = false
@@ -97,16 +97,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "p":
 			if m.commandCallback != nil && m.state.ActiveSession != nil {
 				if m.state.ActiveSession.Status == domain.SessionStatusRunning {
-					m.commandCallback(ports.CmdPause)
+					_ = m.commandCallback(ports.CmdPause)
 				} else {
-					m.commandCallback(ports.CmdResume)
+					_ = m.commandCallback(ports.CmdResume)
 				}
 			}
 			m.confirmBreak = false
 		case "b":
 			if m.completed && m.completedSessionType == domain.SessionTypeWork {
 				if m.commandCallback != nil {
-					m.commandCallback(ports.CmdBreak)
+					_ = m.commandCallback(ports.CmdBreak)
 					m.completed = false
 					m.notified = false
 				}
@@ -114,8 +114,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.confirmBreak {
 					if m.commandCallback != nil {
 						// Stop the active session first, then start break
-						m.commandCallback(ports.CmdStop)
-						m.commandCallback(ports.CmdBreak)
+						_ = m.commandCallback(ports.CmdStop)
+						_ = m.commandCallback(ports.CmdBreak)
 						m.completed = false
 						m.notified = false
 						m.confirmBreak = false
@@ -126,7 +126,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "x":
 			if m.commandCallback != nil {
-				m.commandCallback(ports.CmdStop)
+				_ = m.commandCallback(ports.CmdStop)
 			}
 			m.confirmBreak = false
 			return m, tea.Quit

--- a/internal/adapters/tui/timer.go
+++ b/internal/adapters/tui/timer.go
@@ -17,7 +17,6 @@ type Timer struct {
 	commandCallback    func(ports.TimerCommand) error
 	onSessionComplete  func(domain.SessionType)
 	completionInfo     *domain.CompletionInfo
-	lastError          error
 }
 
 // NewTimer creates a new TUI timer adapter.

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -120,13 +120,13 @@ func TestStartPauseResumeStop(t *testing.T) {
 	
 	t.Run("start pause resume stop flow", func(t *testing.T) {
 		// Start
-		session, err := pomodoroSvc.StartPomodoro(ctx, services.StartPomodoroRequest{})
+		_, err := pomodoroSvc.StartPomodoro(ctx, services.StartPomodoroRequest{})
 		if err != nil {
 			t.Fatalf("failed to start: %v", err)
 		}
 		
 		// Pause
-		session, err = pomodoroSvc.PauseSession(ctx)
+		session, err := pomodoroSvc.PauseSession(ctx)
 		if err != nil {
 			t.Fatalf("failed to pause: %v", err)
 		}
@@ -141,7 +141,7 @@ func TestStartPauseResumeStop(t *testing.T) {
 		}
 		
 		// Resume
-		session, err = pomodoroSvc.ResumeSession(ctx)
+		_, err = pomodoroSvc.ResumeSession(ctx)
 		if err != nil {
 			t.Fatalf("failed to resume: %v", err)
 		}

--- a/internal/services/pomodoro_service_test.go
+++ b/internal/services/pomodoro_service_test.go
@@ -12,7 +12,7 @@ func clearSessions(t *testing.T, store ports.Storage, ctx context.Context) {
 	session, _ := store.Sessions().FindActive(ctx)
 	if session != nil {
 		session.Complete()
-		store.Sessions().Update(ctx, session)
+		_ = store.Sessions().Update(ctx, session)
 	}
 }
 
@@ -111,7 +111,7 @@ func TestPomodoroService_PauseAndResume(t *testing.T) {
 
 	// Complete existing and start new
 	clearSessions(t, store, ctx)
-	service.StartPomodoro(ctx, StartPomodoroRequest{})
+	_, _ = service.StartPomodoro(ctx, StartPomodoroRequest{})
 
 	t.Run("pause session", func(t *testing.T) {
 		session, err := service.PauseSession(ctx)
@@ -143,7 +143,7 @@ func TestPomodoroService_StopSession(t *testing.T) {
 
 	// Complete existing and start new
 	clearSessions(t, store, ctx)
-	service.StartPomodoro(ctx, StartPomodoroRequest{})
+	_, _ = service.StartPomodoro(ctx, StartPomodoroRequest{})
 
 	t.Run("stop session", func(t *testing.T) {
 		session, err := service.StopSession(ctx)
@@ -167,7 +167,7 @@ func TestPomodoroService_CancelSession(t *testing.T) {
 	ctx := context.Background()
 
 	clearSessions(t, store, ctx)
-	service.StartPomodoro(ctx, StartPomodoroRequest{})
+	_, _ = service.StartPomodoro(ctx, StartPomodoroRequest{})
 
 	t.Run("cancel session", func(t *testing.T) {
 		err := service.CancelSession(ctx)
@@ -224,8 +224,8 @@ func TestPomodoroService_GetTaskHistory(t *testing.T) {
 
 	// Complete existing
 	clearSessions(t, store, ctx)
-	service.StartPomodoro(ctx, StartPomodoroRequest{TaskID: &task.ID})
-	service.StopSession(ctx)
+	_, _ = service.StartPomodoro(ctx, StartPomodoroRequest{TaskID: &task.ID})
+	_, _ = service.StopSession(ctx)
 
 	t.Run("get task history", func(t *testing.T) {
 		history, err := service.GetTaskHistory(ctx, task.ID)
@@ -250,8 +250,8 @@ func TestPomodoroService_GetRecentSessions(t *testing.T) {
 
 	// Create multiple sessions
 	for i := 0; i < 3; i++ {
-		service.StartPomodoro(ctx, StartPomodoroRequest{})
-		service.StopSession(ctx)
+		_, _ = service.StartPomodoro(ctx, StartPomodoroRequest{})
+		_, _ = service.StopSession(ctx)
 	}
 
 	t.Run("get recent sessions", func(t *testing.T) {

--- a/internal/services/state_service.go
+++ b/internal/services/state_service.go
@@ -13,7 +13,6 @@ type StateService struct {
 	storage       ports.Storage
 	taskService   *TaskService
 	pomodoroSvc   *PomodoroService
-	gitDetector   ports.GitDetector
 }
 
 // NewStateService creates a new state service.

--- a/internal/services/task_service_test.go
+++ b/internal/services/task_service_test.go
@@ -63,8 +63,8 @@ func TestTaskService_ListTasks(t *testing.T) {
 	ctx := context.Background()
 
 	// Create test tasks
-	service.AddTask(ctx, AddTaskRequest{Title: "Task 1"})
-	service.AddTask(ctx, AddTaskRequest{Title: "Task 2"})
+	_, _ = service.AddTask(ctx, AddTaskRequest{Title: "Task 1"})
+	_, _ = service.AddTask(ctx, AddTaskRequest{Title: "Task 2"})
 
 	t.Run("list all tasks", func(t *testing.T) {
 		tasks, err := service.ListTasks(ctx, ListTasksRequest{})


### PR DESCRIPTION
## Summary
- Fix all 29 golangci-lint errors (errcheck, unused, staticcheck)
- Remove Windows CI job from workflow

## Changes
- **errcheck**: Add explicit `_ =` for unchecked error returns across model.go, test files, start.go, stop.go
- **unused**: Remove `lastError` field, `isUniqueConstraintError` func, `gitDetector` field
- **staticcheck SA4006**: Discard unused session values in integration tests
- **staticcheck SA5011**: Use `t.Fatal` for nil checks before dereference in cmd tests
- **CI**: Remove `build-windows` job