### PR TITLE
feat: TUI visual overhaul — big timer, theming, UX polish

### DIFF
--- a/internal/adapters/tui/bigfont.go
+++ b/internal/adapters/tui/bigfont.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// digitMap maps each digit character (0-9) and colon to a 5-line ASCII representation.
+// Each digit is 4 chars wide, colon is 1 char wide.
+var digitMap = map[rune][5]string{
+	'0': {
+		"████",
+		"█  █",
+		"█  █",
+		"█  █",
+		"████",
+	},
+	'1': {
+		" █ ",
+		"██ ",
+		" █ ",
+		" █ ",
+		"███",
+	},
+	'2': {
+		"████",
+		"   █",
+		"████",
+		"█   ",
+		"████",
+	},
+	'3': {
+		"████",
+		"   █",
+		"████",
+		"   █",
+		"████",
+	},
+	'4': {
+		"█  █",
+		"█  █",
+		"████",
+		"   █",
+		"   █",
+	},
+	'5': {
+		"████",
+		"█   ",
+		"████",
+		"   █",
+		"████",
+	},
+	'6': {
+		"████",
+		"█   ",
+		"████",
+		"█  █",
+		"████",
+	},
+	'7': {
+		"████",
+		"   █",
+		"  █ ",
+		" █  ",
+		" █  ",
+	},
+	'8': {
+		"████",
+		"█  █",
+		"████",
+		"█  █",
+		"████",
+	},
+	'9': {
+		"████",
+		"█  █",
+		"████",
+		"   █",
+		"████",
+	},
+	':': {
+		" ",
+		"█",
+		" ",
+		"█",
+		" ",
+	},
+}
+
+// renderBigTime takes a time string like "14:32" and returns a multi-line
+// styled ASCII art representation. Falls back to a single styled line
+// if the terminal width is less than 40.
+func renderBigTime(timeStr string, color lipgloss.Color, width int) string {
+	if width < 40 {
+		style := lipgloss.NewStyle().Bold(true).Foreground(color)
+		return style.Render(timeStr)
+	}
+
+	lines := [5]string{}
+	for _, ch := range timeStr {
+		glyph, ok := digitMap[ch]
+		if !ok {
+			continue
+		}
+		spacing := " "
+		if ch == ':' {
+			spacing = " "
+		}
+		for i := 0; i < 5; i++ {
+			if lines[i] != "" {
+				lines[i] += spacing
+			}
+			lines[i] += glyph[i]
+		}
+	}
+
+	style := lipgloss.NewStyle().Bold(true).Foreground(color)
+	styled := make([]string, 5)
+	for i, line := range lines {
+		styled[i] = style.Render(line)
+	}
+
+	return strings.Join(styled, "\n")
+}


### PR DESCRIPTION
## Summary
- Add big ASCII art timer digits using `█` block characters — timer is now the hero element
- Color-code sessions dynamically: red for work, teal/green for breaks, gray when paused
- Show `⏸ PAUSED` badge with gray timer and progress bar on pause
- Dynamic progress bar gradient that matches session type
- Rename `[x] stop` → `[x] finish`
- Hide stats line from active timer view (kept on completion screens)
- Add `[s]tart` option from "No active session" screen
- Bug fix: prevent requesting a break during a break session

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Manual: start work session → big red digits, no stats line
- [ ] Manual: press `p` → gray digits, PAUSED badge, gray progress bar
- [ ] Manual: press `p` again → resumes with red theme
- [ ] Manual: press `b` during work → confirmation, then break starts with teal theme
- [ ] Manual: during break → `[b]reak` not shown in help, `b` key does nothing
- [ ] Manual: "No active session" screen shows `[s]tart  [q]uit`
- [ ] Manual: help says `[x] finish` not `[x] stop`