### PR TITLE
feat: compact 3-line timer font and skip-break keybind

### DIFF
--- a/internal/adapters/tui/bigfont.go
+++ b/internal/adapters/tui/bigfont.go
@@ -6,90 +6,68 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// digitMap maps each digit character (0-9) and colon to a 5-line ASCII representation.
-// Each digit is 4 chars wide, colon is 1 char wide.
-var digitMap = map[rune][5]string{
+// digitMap maps each digit character (0-9) and colon to a 3-line half-block representation.
+// Each digit is 3 chars wide, colon is 1 char wide.
+var digitMap = map[rune][3]string{
 	'0': {
-		"████",
-		"█  █",
-		"█  █",
-		"█  █",
-		"████",
+		"█▀█",
+		"█ █",
+		"▀▀▀",
 	},
 	'1': {
+		"▀█ ",
 		" █ ",
-		"██ ",
-		" █ ",
-		" █ ",
-		"███",
+		"▀▀▀",
 	},
 	'2': {
-		"████",
-		"   █",
-		"████",
-		"█   ",
-		"████",
+		"▀▀█",
+		"█▀▀",
+		"▀▀▀",
 	},
 	'3': {
-		"████",
-		"   █",
-		"████",
-		"   █",
-		"████",
+		"▀▀█",
+		"▀▀█",
+		"▀▀▀",
 	},
 	'4': {
-		"█  █",
-		"█  █",
-		"████",
-		"   █",
-		"   █",
+		"█ █",
+		"▀▀█",
+		"  ▀",
 	},
 	'5': {
-		"████",
-		"█   ",
-		"████",
-		"   █",
-		"████",
+		"█▀▀",
+		"▀▀█",
+		"▀▀▀",
 	},
 	'6': {
-		"████",
-		"█   ",
-		"████",
-		"█  █",
-		"████",
+		"█▀▀",
+		"█▀█",
+		"▀▀▀",
 	},
 	'7': {
-		"████",
-		"   █",
-		"  █ ",
-		" █  ",
-		" █  ",
+		"▀▀█",
+		"  █",
+		"  ▀",
 	},
 	'8': {
-		"████",
-		"█  █",
-		"████",
-		"█  █",
-		"████",
+		"█▀█",
+		"█▀█",
+		"▀▀▀",
 	},
 	'9': {
-		"████",
-		"█  █",
-		"████",
-		"   █",
-		"████",
+		"█▀█",
+		"▀▀█",
+		"▀▀▀",
 	},
 	':': {
+		"▀",
 		" ",
-		"█",
-		" ",
-		"█",
-		" ",
+		"▀",
 	},
 }
 
 // renderBigTime takes a time string like "14:32" and returns a multi-line
-// styled ASCII art representation. Falls back to a single styled line
+// styled half-block representation. Falls back to a single styled line
 // if the terminal width is less than 40.
 func renderBigTime(timeStr string, color lipgloss.Color, width int) string {
 	if width < 40 {
@@ -97,7 +75,7 @@ func renderBigTime(timeStr string, color lipgloss.Color, width int) string {
 		return style.Render(timeStr)
 	}
 
-	lines := [5]string{}
+	lines := [3]string{}
 	for _, ch := range timeStr {
 		glyph, ok := digitMap[ch]
 		if !ok {
@@ -107,7 +85,7 @@ func renderBigTime(timeStr string, color lipgloss.Color, width int) string {
 		if ch == ':' {
 			spacing = " "
 		}
-		for i := 0; i < 5; i++ {
+		for i := 0; i < 3; i++ {
 			if lines[i] != "" {
 				lines[i] += spacing
 			}
@@ -116,7 +94,7 @@ func renderBigTime(timeStr string, color lipgloss.Color, width int) string {
 	}
 
 	style := lipgloss.NewStyle().Bold(true).Foreground(color)
-	styled := make([]string, 5)
+	styled := make([]string, 3)
 	for i, line := range lines {
 		styled[i] = style.Render(line)
 	}

--- a/internal/adapters/tui/model.go
+++ b/internal/adapters/tui/model.go
@@ -101,6 +101,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.completed = false
 				m.notified = false
 				m.confirmBreak = false
+			} else if !m.completed && m.state.ActiveSession != nil && m.state.ActiveSession.IsBreakSession() && m.commandCallback != nil {
+				_ = m.commandCallback(ports.CmdStop)
+				_ = m.commandCallback(ports.CmdStart)
+				m.completed = false
+				m.notified = false
 			} else if !m.completed && m.state.ActiveSession == nil && m.commandCallback != nil {
 				_ = m.commandCallback(ports.CmdStart)
 				m.completed = false
@@ -350,7 +355,7 @@ func (m Model) viewActiveSession(sections []string) []string {
 	if m.confirmBreak {
 		sections = append(sections, helpStyle.Render("End session and start break? Press [b] again to confirm"))
 	} else if session.IsBreakSession() {
-		sections = append(sections, helpStyle.Render("[p]ause  [x] finish  [q]uit"))
+		sections = append(sections, helpStyle.Render("[s] skip  [p]ause  [x] finish  [q]uit"))
 	} else {
 		sections = append(sections, helpStyle.Render("[p]ause  [x] finish  [b]reak  [q]uit"))
 	}


### PR DESCRIPTION
## Summary
- Replace 5-line full-block digit map with compact 3-line half-block font — 40% less vertical space, cleaner modern look
- Add `[s] skip` keybind during active break sessions to stop the break and immediately start a new work session
- Update break session help text to show the new skip option

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Manual: timer shows 3-line half-block digits
- [ ] Manual: during break, `[s]` skips break and starts work session
- [ ] Manual: during work, `[s]` does nothing