### PR TITLE
Fix notification sound support and stop command notification type

### DIFF
--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -34,7 +34,14 @@ var stopCmd = &cobra.Command{
 
 		// Send notification if enabled
 		if notifier != nil && notifier.IsEnabled() {
-			_ = notifier.NotifyPomodoroComplete(session.Duration.String())
+			switch session.Type {
+			case domain.SessionTypeWork:
+				_ = notifier.NotifyPomodoroComplete(session.Duration.String())
+			case domain.SessionTypeShortBreak:
+				_ = notifier.NotifyBreakComplete("Short")
+			case domain.SessionTypeLongBreak:
+				_ = notifier.NotifyBreakComplete("Long")
+			}
 		}
 
 		if jsonOutput {

--- a/internal/adapters/notification/notifier.go
+++ b/internal/adapters/notification/notifier.go
@@ -24,7 +24,15 @@ func (n *Notifier) Notify(title, message string) error {
 		return nil
 	}
 
-	return beeep.Notify(title, message, "")
+	if err := beeep.Notify(title, message, ""); err != nil {
+		return err
+	}
+
+	if n.cfg.Sound {
+		_ = beeep.Beep(beeep.DefaultFreq, beeep.DefaultDuration)
+	}
+
+	return nil
 }
 
 // NotifyPomodoroComplete displays a notification when a pomodoro session completes.


### PR DESCRIPTION
## Summary
- Play notification sound via `beeep.Beep()` when `sound = true` in config — this setting was previously defined but never used
- Send the correct notification type in `flow stop` based on session type (work → "Pomodoro Complete!", break → "Break Over!") instead of always sending "Pomodoro Complete!"

## Test plan
- [ ] Run `flow stop` during a work session → should show "Pomodoro Complete!"
- [ ] Run `flow stop` during a break → should show "Break Over!"
- [ ] Set `sound = true` in `~/.flow/config.toml` → should hear a beep on notification
- [ ] Set `sound = false` → no beep, visual notification only