### PR TITLE
feat: Product gaps 2026-02-20 (issues #55-#59)

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -107,6 +107,9 @@ func launchTUI(_ context.Context, state *domain.CurrentState, workingDir string)
 				return err
 			case ports.CmdCancel:
 				return app.pomodoro.CancelSession(ctx)
+			case ports.CmdVoid:
+				_, err := app.pomodoro.VoidSession(ctx)
+				return err
 			case ports.CmdBreak:
 				_, err := app.pomodoro.StartBreak(ctx, workingDir)
 				return err

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -152,6 +152,13 @@ func launchTUI(_ context.Context, state *domain.CurrentState, workingDir string)
 			}
 			return app.pomodoro.SetEnergizeActivity(ctx, recent[0].ID, activity)
 		},
+		OutcomeAchievedCallback: func(achieved string) error {
+			recent, err := app.pomodoro.GetRecentSessions(ctx, 1)
+			if err != nil || len(recent) == 0 {
+				return nil
+			}
+			return app.pomodoro.SetOutcomeAchieved(ctx, recent[0].ID, achieved)
+		},
 		OnSessionComplete: func(sessionType domain.SessionType) {
 			if app.notifier == nil || !app.notifier.IsEnabled() {
 				return

--- a/cmd/reflect.go
+++ b/cmd/reflect.go
@@ -183,6 +183,21 @@ func runReflectToday(ctx context.Context, now time.Time) error {
 
 	fmt.Printf("  %s  %s\n", dimStyle.Render("Sessions:"), valueStyle.Render(fmt.Sprintf("%d", stats.WorkSessions)))
 	fmt.Printf("  %s  %s\n", dimStyle.Render("Work time:"), valueStyle.Render(formatMinutes(stats.TotalWorkTime)))
+	if app.config.MakeTime.HighlightTargetMinutes > 0 {
+		target := time.Duration(app.config.MakeTime.HighlightTargetMinutes) * time.Minute
+		pct := 0
+		if target > 0 {
+			pct = int(stats.TotalWorkTime * 100 / target)
+		}
+		if pct > 100 {
+			pct = 100
+		}
+		fmt.Printf("  %s  %s %s\n",
+			dimStyle.Render("Highlight target:"),
+			valueStyle.Render(formatMinutes(target)),
+			dimStyle.Render(fmt.Sprintf("(%d%% complete)", pct)),
+		)
+	}
 	fmt.Println()
 
 	// Today's highlight

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,4 +71,5 @@ func init() {
 	rootCmd.AddCommand(resumeCmd)
 	rootCmd.AddCommand(completeCmd)
 	rootCmd.AddCommand(resetCmd)
+	rootCmd.AddCommand(voidCmd)
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -76,6 +76,19 @@ var stopCmd = &cobra.Command{
 					}
 					_ = app.pomodoro.SetShutdownRitual(ctx, session.ID, ritual)
 				}
+
+				// Outcome review: ask if intended outcome was achieved
+				if session.IntendedOutcome != "" {
+					fmt.Println()
+					fmt.Printf("  Did you achieve your intended outcome? (y/p/n): %s\n", session.IntendedOutcome)
+					fmt.Print("  Answer [y]es/[p]artially/[n]o: ")
+					if scanner.Scan() {
+						answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+						if answer == "y" || answer == "p" || answer == "n" {
+							_ = app.pomodoro.SetOutcomeAchieved(ctx, session.ID, answer)
+						}
+					}
+				}
 				fmt.Println()
 			case domain.MethodologyMakeTime:
 				scanner := bufio.NewScanner(os.Stdin)

--- a/cmd/void.go
+++ b/cmd/void.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var voidCmd = &cobra.Command{
+	Use:   "void",
+	Short: "Void (invalidate) the current session due to interruption",
+	Long: `Mark the current session as interrupted. Interrupted sessions are not
+counted in productivity stats — use this when you were significantly
+disrupted and the session no longer represents focused work.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+
+		session, err := app.pomodoro.VoidSession(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to void session: %w", err)
+		}
+
+		fmt.Printf("Session voided. Duration: %s (not counted in stats)\n", session.Duration)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(voidCmd)
+}

--- a/cmd/wizard.go
+++ b/cmd/wizard.go
@@ -169,6 +169,28 @@ func runWizard(cmd *cobra.Command, args []string) error {
 
 		customDuration := presets[result.Index].Duration
 
+		// Laser checklist (Make Time only)
+		if mode.HasLaserChecklist() {
+			fmt.Println()
+			fmt.Println("  Laser Checklist:")
+			checklistItems := []string{
+				"Phone on Do Not Disturb?",
+				"Notifications off?",
+				"Distracting tabs/apps closed?",
+			}
+			for _, item := range checklistItems {
+				checkResult := tui.RunPicker(item, []tui.PickerItem{
+					{Label: "Yes", Desc: "Ready to focus"},
+					{Label: "No", Desc: "Skip for now"},
+				}, "", &app.config.Theme)
+				if checkResult.Aborted {
+					return nil
+				}
+				// User can skip with "No" and still proceed
+			}
+			fmt.Println()
+		}
+
 		// 2. Task selection via styled picker
 		var taskName string
 		var sessionTags []string

--- a/internal/adapters/storage/sqlite.go
+++ b/internal/adapters/storage/sqlite.go
@@ -121,6 +121,7 @@ func (s *sqliteStorage) Migrate() error {
 		"ALTER TABLE sessions ADD COLUMN tags TEXT",
 		"ALTER TABLE sessions ADD COLUMN energize_activity TEXT",
 		"ALTER TABLE sessions ADD COLUMN shutdown_ritual TEXT",
+		"ALTER TABLE sessions ADD COLUMN outcome_achieved TEXT",
 	}
 
 	for _, m := range migrations {

--- a/internal/adapters/tui/completion.go
+++ b/internal/adapters/tui/completion.go
@@ -33,6 +33,11 @@ type completionState struct {
 	distractionReviewMode bool
 	distractionReviewDone bool
 
+	// Deep Work: outcome review (did you achieve the intended outcome?)
+	outcomeReviewMode bool
+	outcomeReviewDone bool
+	outcomeAchieved   string // y/p/n
+
 	// Make Time: focus score
 	focusScore      *int
 	focusScoreSaved bool
@@ -61,6 +66,9 @@ func (c *completionState) reset() {
 	c.distractions = nil
 	c.distractionReviewMode = false
 	c.distractionReviewDone = false
+	c.outcomeReviewMode = false
+	c.outcomeReviewDone = false
+	c.outcomeAchieved = ""
 	c.energizeActivity = ""
 	c.energizeSaved = false
 	c.shutdownRitualMode = false
@@ -75,9 +83,13 @@ func (c *completionState) promptsDone(mode methodology.Mode, completedType domai
 	if mode == nil {
 		return true
 	}
-	// Deep Work: need shutdown ritual complete (or accomplishment saved) and distraction review done
+	// Deep Work: need shutdown ritual complete (or accomplishment saved), outcome review if applicable, and distraction review done
 	if mode.HasShutdownRitual() && completedType == domain.SessionTypeWork {
 		if !c.shutdownComplete && !c.accomplishmentSaved {
+			return false
+		}
+		// Outcome review: if there was an intended outcome, ask if achieved
+		if c.completedIntendedOutcome != "" && !c.outcomeReviewDone {
 			return false
 		}
 		if len(c.distractions) > 0 && !c.distractionReviewDone {

--- a/internal/adapters/tui/inline.go
+++ b/internal/adapters/tui/inline.go
@@ -590,13 +590,13 @@ func (m InlineModel) viewTimer() string {
 	}
 
 	if m.state.ActiveSession == nil {
-		// Make Time: show Highlight prominently
+		// Make Time: show Highlight prominently if it's today's highlight
 		if m.mode != nil && m.mode.HasHighlight() {
 			var b strings.Builder
 			b.WriteString(accent.Render("  Make Time"))
 			b.WriteString("\n")
-			if m.state.ActiveTask != nil {
-				b.WriteString(accent.Render(fmt.Sprintf("  Today's Highlight: %s", m.state.ActiveTask.Title)))
+			if m.state.ActiveTask != nil && m.state.ActiveTask.IsTodayHighlight() {
+				b.WriteString(accent.Render(fmt.Sprintf("  ★ Today's Highlight: %s", m.state.ActiveTask.Title)))
 				b.WriteString("\n")
 			} else {
 				b.WriteString(dim.Render("  No Highlight set for today"))

--- a/internal/adapters/tui/inline.go
+++ b/internal/adapters/tui/inline.go
@@ -48,6 +48,11 @@ type InlineModel struct {
 	// Setup: task name
 	taskInput textinput.Model
 
+	// Setup: laser checklist (Make Time only)
+	laserChecklistCursor int
+	laserChecklist       [3]bool // Phone DND, Notifications off, Tabs closed
+	laserChecklistDone   bool
+
 	// Setup: intended outcome (Deep Work only)
 	outcomeInput    textinput.Model
 	intendedOutcome string
@@ -159,6 +164,8 @@ func (m InlineModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updatePickMode(msg)
 	case phasePickDuration:
 		return m.updatePickDuration(msg)
+	case phaseLaserChecklist:
+		return m.updateLaserChecklist(msg)
 	case phaseTaskSelect:
 		return m.updateTaskSelect(msg)
 	case phaseTaskName:
@@ -526,6 +533,8 @@ func (m InlineModel) View() string {
 		return m.viewPickMode()
 	case phasePickDuration:
 		return m.viewPickDuration()
+	case phaseLaserChecklist:
+		return m.viewLaserChecklist()
 	case phaseTaskSelect:
 		return m.viewTaskSelect()
 	case phaseTaskName:

--- a/internal/adapters/tui/inline.go
+++ b/internal/adapters/tui/inline.go
@@ -561,6 +561,24 @@ func (m InlineModel) viewTimer() string {
 	}
 
 	if m.state.ActiveSession == nil {
+		// Make Time: show Highlight prominently
+		if m.mode != nil && m.mode.HasHighlight() {
+			var b strings.Builder
+			b.WriteString(accent.Render("  Make Time"))
+			b.WriteString("\n")
+			if m.state.ActiveTask != nil {
+				b.WriteString(accent.Render(fmt.Sprintf("  Today's Highlight: %s", m.state.ActiveTask.Title)))
+				b.WriteString("\n")
+			} else {
+				b.WriteString(dim.Render("  No Highlight set for today"))
+				b.WriteString("\n")
+				b.WriteString(dim.Render("  Start a session to choose your Highlight"))
+				b.WriteString("\n")
+			}
+			b.WriteString(dim.Render("  [s]tart  [c]lose"))
+			b.WriteString("\n")
+			return b.String()
+		}
 		return dim.Render("  No active session") + "\n" +
 			dim.Render("  [s]tart  [c]lose") + "\n"
 	}

--- a/internal/adapters/tui/inline.go
+++ b/internal/adapters/tui/inline.go
@@ -417,6 +417,16 @@ func (m InlineModel) updateTimer(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.confirmFinish = true
 			m.confirmBreak = false
+		case "v":
+			// Void (interrupt) the current session — not counted in stats
+			if !m.completed && m.state.ActiveSession != nil && m.state.ActiveSession.Type == domain.SessionTypeWork && m.commandCallback != nil {
+				_ = m.commandCallback(ports.CmdVoid)
+				m.completed = false
+				m.notified = false
+				m.confirmBreak = false
+				m.confirmFinish = false
+				m.resetCompletionState()
+			}
 		case "m":
 			// Switch mode: cancel active session (if any) and go back to mode picker
 			if !m.completed && m.state.ActiveSession != nil && m.commandCallback != nil {
@@ -729,12 +739,12 @@ func (m InlineModel) viewInlineActive(accent, dim, pausedStyle lipgloss.Style) s
 		if session.Status == domain.SessionStatusPaused {
 			pauseAction = "[p]resume"
 		}
-		helpText := fmt.Sprintf("  %s [f]inish [b]reak [m]ode [c]lose", pauseAction)
+		helpText := fmt.Sprintf("  %s [f]inish [v]oid [b]reak [m]ode [c]lose", pauseAction)
 		if m.mode != nil && m.mode.HasDistractionLog() && session.Status == domain.SessionStatusRunning {
 			if len(m.distractions) > 0 {
-				helpText = fmt.Sprintf("  %s [d]istraction(%d) [f]inish [b]reak [m]ode [c]lose", pauseAction, len(m.distractions))
+				helpText = fmt.Sprintf("  %s [d]istraction(%d) [f]inish [v]oid [b]reak [m]ode [c]lose", pauseAction, len(m.distractions))
 			} else {
-				helpText = fmt.Sprintf("  %s [d]istraction [f]inish [b]reak [m]ode [c]lose", pauseAction)
+				helpText = fmt.Sprintf("  %s [d]istraction [f]inish [v]oid [b]reak [m]ode [c]lose", pauseAction)
 			}
 		}
 		helpText += fmt.Sprintf("  tab:notify %s", notifLabel)

--- a/internal/adapters/tui/timer.go
+++ b/internal/adapters/tui/timer.go
@@ -23,6 +23,7 @@ type Timer struct {
 	shutdownRitualCallback  func(domain.ShutdownRitual) error
 	focusScoreCallback      func(int) error
 	energizeCallback        func(string) error
+	outcomeAchievedCallback func(string) error
 	completionInfo          *domain.CompletionInfo
 	theme                   *config.ThemeConfig
 	inline                  bool
@@ -70,6 +71,7 @@ type TimerConfig struct {
 	ShutdownRitualCallback  func(domain.ShutdownRitual) error
 	FocusScoreCallback      func(int) error
 	EnergizeCallback        func(string) error
+	OutcomeAchievedCallback func(string) error
 	CompletionInfo          *domain.CompletionInfo
 	AutoBreak               bool
 	NotificationsEnabled    bool
@@ -95,6 +97,7 @@ func (t *Timer) Configure(cfg TimerConfig) {
 	t.shutdownRitualCallback = cfg.ShutdownRitualCallback
 	t.focusScoreCallback = cfg.FocusScoreCallback
 	t.energizeCallback = cfg.EnergizeCallback
+	t.outcomeAchievedCallback = cfg.OutcomeAchievedCallback
 	t.completionInfo = cfg.CompletionInfo
 	t.autoBreak = cfg.AutoBreak
 	t.notificationsEnabled = cfg.NotificationsEnabled
@@ -140,6 +143,7 @@ func (t *Timer) Run(ctx context.Context, initialState *domain.CurrentState) erro
 	model.shutdownRitualCallback = t.shutdownRitualCallback
 	model.focusScoreCallback = t.focusScoreCallback
 	model.energizeCallback = t.energizeCallback
+	model.outcomeAchievedCallback = t.outcomeAchievedCallback
 	model.mode = t.mode
 	model.autoBreak = t.autoBreak
 	model.notificationsEnabled = t.notificationsEnabled
@@ -181,6 +185,7 @@ func (t *Timer) runInline(ctx context.Context, initialState *domain.CurrentState
 	model.shutdownRitualCallback = t.shutdownRitualCallback
 	model.focusScoreCallback = t.focusScoreCallback
 	model.energizeCallback = t.energizeCallback
+	model.outcomeAchievedCallback = t.outcomeAchievedCallback
 	model.presets = t.presets
 	model.breakInfo = t.breakInfo
 	model.onStartSession = t.onStartSession

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -18,10 +18,11 @@ const (
 type SessionStatus string
 
 const (
-	SessionStatusRunning   SessionStatus = "running"
-	SessionStatusPaused    SessionStatus = "paused"
-	SessionStatusCompleted SessionStatus = "completed"
-	SessionStatusCancelled SessionStatus = "cancelled"
+	SessionStatusRunning     SessionStatus = "running"
+	SessionStatusPaused      SessionStatus = "paused"
+	SessionStatusCompleted   SessionStatus = "completed"
+	SessionStatusCancelled   SessionStatus = "cancelled"
+	SessionStatusInterrupted SessionStatus = "interrupted"
 )
 
 // ShutdownRitual captures the structured end-of-session reflection for Deep Work mode.
@@ -149,6 +150,21 @@ func (s *PomodoroSession) Complete() {
 // Cancel aborts the session.
 func (s *PomodoroSession) Cancel() {
 	s.Status = SessionStatusCancelled
+}
+
+// Interrupt marks the session as interrupted (voided), recording actual elapsed time.
+func (s *PomodoroSession) Interrupt() {
+	// Record actual elapsed time before voiding
+	elapsed := time.Since(s.StartedAt)
+	if s.Status == SessionStatusPaused && s.PausedAt != nil {
+		elapsed = s.PausedAt.Sub(s.StartedAt)
+	}
+	if elapsed >= time.Second && elapsed < s.Duration {
+		s.Duration = elapsed
+	}
+	now := time.Now()
+	s.CompletedAt = &now
+	s.Status = SessionStatusInterrupted
 }
 
 // RemainingTime returns how much time is left in the session.

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -65,6 +65,7 @@ type PomodoroSession struct {
 	IntendedOutcome  string
 	Tags             []string
 	EnergizeActivity string
+	OutcomeAchieved  string // y/p/n for Deep Work outcome review
 }
 
 // PomodoroConfig holds configuration for pomodoro sessions.

--- a/internal/domain/state.go
+++ b/internal/domain/state.go
@@ -104,6 +104,8 @@ func GetStatusLabel(s SessionStatus) string {
 		return "Completed"
 	case SessionStatusCancelled:
 		return "Cancelled"
+	case SessionStatusInterrupted:
+		return "Interrupted"
 	default:
 		return "Unknown"
 	}

--- a/internal/domain/task.go
+++ b/internal/domain/task.go
@@ -59,6 +59,11 @@ func (t *Task) IsHighlightForDate(date time.Time) bool {
 	return d.Equal(h)
 }
 
+// IsTodayHighlight returns true if this task is today's highlight.
+func (t *Task) IsTodayHighlight() bool {
+	return t.IsHighlightForDate(time.Now())
+}
+
 // NewTask creates a new task with the given title.
 func NewTask(title string) (*Task, error) {
 	if err := validateTaskTitle(title); err != nil {

--- a/internal/methodology/methodology.go
+++ b/internal/methodology/methodology.go
@@ -39,6 +39,9 @@ type Mode interface {
 	// HasHighlight returns true if this mode uses a daily highlight concept.
 	HasHighlight() bool
 
+	// HasLaserChecklist returns true if this mode shows a pre-session laser checklist.
+	HasLaserChecklist() bool
+
 	// CompletionTitle returns the title shown on session completion.
 	CompletionTitle() string
 
@@ -87,6 +90,7 @@ func (p *pomodoroMode) HasEnergizeReminder() bool  { return false }
 func (p *pomodoroMode) HasFocusScore() bool        { return false }
 func (p *pomodoroMode) HasShutdownRitual() bool    { return false }
 func (p *pomodoroMode) HasHighlight() bool         { return false }
+func (p *pomodoroMode) HasLaserChecklist() bool    { return false }
 func (p *pomodoroMode) CompletionTitle() string    { return "Session complete! Great work." }
 func (p *pomodoroMode) DeepWorkGoalHours() float64 { return 0 }
 func (p *pomodoroMode) Description() string {
@@ -119,6 +123,7 @@ func (d *deepWorkMode) HasEnergizeReminder() bool { return false }
 func (d *deepWorkMode) HasFocusScore() bool       { return false }
 func (d *deepWorkMode) HasShutdownRitual() bool   { return true }
 func (d *deepWorkMode) HasHighlight() bool        { return false }
+func (d *deepWorkMode) HasLaserChecklist() bool   { return false }
 func (d *deepWorkMode) CompletionTitle() string   { return "Deep Work Session Complete." }
 func (d *deepWorkMode) DeepWorkGoalHours() float64 {
 	if d.cfg != nil {
@@ -156,6 +161,7 @@ func (mt *makeTimeMode) HasEnergizeReminder() bool  { return true }
 func (mt *makeTimeMode) HasFocusScore() bool        { return true }
 func (mt *makeTimeMode) HasShutdownRitual() bool    { return false }
 func (mt *makeTimeMode) HasHighlight() bool         { return true }
+func (mt *makeTimeMode) HasLaserChecklist() bool    { return true }
 func (mt *makeTimeMode) CompletionTitle() string    { return "Session Complete!" }
 func (mt *makeTimeMode) DeepWorkGoalHours() float64 { return 0 }
 func (mt *makeTimeMode) Description() string {

--- a/internal/ports/timer.go
+++ b/internal/ports/timer.go
@@ -57,6 +57,9 @@ const (
 
 	// CmdQuit exits the application.
 	CmdQuit TimerCommand = "quit"
+
+	// CmdVoid marks the current session as interrupted (not counted in stats).
+	CmdVoid TimerCommand = "void"
 )
 
 // Timer is the combined interface for TUI timer operations.

--- a/internal/services/pomodoro_service.go
+++ b/internal/services/pomodoro_service.go
@@ -260,6 +260,22 @@ func (s *PomodoroService) SetShutdownRitual(ctx context.Context, sessionID strin
 	return s.storage.Sessions().Update(ctx, session)
 }
 
+// SetOutcomeAchieved records whether the intended outcome was achieved (y/p/n) on a session (Deep Work).
+func (s *PomodoroService) SetOutcomeAchieved(ctx context.Context, sessionID string, achieved string) error {
+	if achieved != "y" && achieved != "p" && achieved != "n" {
+		return fmt.Errorf("outcome achieved must be 'y', 'p', or 'n', got %s", achieved)
+	}
+	session, err := s.storage.Sessions().FindByID(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to find session: %w", err)
+	}
+	if session == nil {
+		return domain.ErrNoActiveSession
+	}
+	session.OutcomeAchieved = achieved
+	return s.storage.Sessions().Update(ctx, session)
+}
+
 // AddSessionNotes adds notes to a pomodoro session.
 func (s *PomodoroService) AddSessionNotes(ctx context.Context, sessionID string, notes string) (*domain.PomodoroSession, error) {
 	session, err := s.storage.Sessions().FindByID(ctx, sessionID)

--- a/internal/services/pomodoro_service.go
+++ b/internal/services/pomodoro_service.go
@@ -192,6 +192,25 @@ func (s *PomodoroService) CancelSession(ctx context.Context) error {
 	return s.storage.Sessions().Update(ctx, session)
 }
 
+// VoidSession marks the active session as interrupted (voided).
+// Interrupted sessions are excluded from productivity stats.
+func (s *PomodoroService) VoidSession(ctx context.Context) (*domain.PomodoroSession, error) {
+	session, err := s.storage.Sessions().FindActive(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find active session: %w", err)
+	}
+	if session == nil {
+		return nil, domain.ErrNoActiveSession
+	}
+
+	session.Interrupt()
+	if err := s.storage.Sessions().Update(ctx, session); err != nil {
+		return nil, fmt.Errorf("failed to void session: %w", err)
+	}
+
+	return session, nil
+}
+
 // LogDistraction appends a distraction entry to the active session.
 func (s *PomodoroService) LogDistraction(ctx context.Context, sessionID string, text string, category string) error {
 	session, err := s.storage.Sessions().FindByID(ctx, sessionID)


### PR DESCRIPTION
## Summary

Implements 5 product-gap issues in priority order.

---

### #56 P0 — MakeTime Laser mode pre-session checklist
- Added `HasLaserChecklist() bool` to the `Mode` interface (methodology.go)
- New `phaseLaserChecklist` phase in inline TUI (inline_setup.go)
- User answers y/n per item or Enter to skip all
- Also wired into wizard fullscreen via `tui.RunPicker`

### #58 P1 — Show Highlight in idle TUI screen (Make Time)
- When `ActiveSession == nil` and mode is MakeTime, viewTimer shows the Highlight prominently
- Shows "No Highlight set for today" guidance if `ActiveTask` is nil

### #57 P1 — DeepWork Outcome review at completion
- Added `OutcomeAchieved string` field to `PomodoroSession`
- SQLite migration: `ALTER TABLE sessions ADD COLUMN outcome_achieved TEXT`
- Updated all SELECT/INSERT/UPDATE queries in session_repository.go
- New `SetOutcomeAchieved()` in PomodoroService
- `handleOutcomeReview()` handler in completion_handlers.go
- Inline TUI: outcome review shown after shutdown ritual (y/p/n/enter)
- Fullscreen model.go: same flow with `[o]` keybind
- `flow stop` asks "Did you achieve it?" when IntendedOutcome is set

### #55 P1 — Pomodoro Void/invalidate on interruption
- Added `SessionStatusInterrupted` constant to domain (not counted in stats)
- `Interrupt()` method records actual elapsed time then sets status
- `VoidSession()` in PomodoroService
- `CmdVoid` added to ports.TimerCommand; dispatched in launch.go
- New `flow void` CLI command
- `[v]` keybind in both inline and fullscreen TUI with updated help text

### #59 P2 — Stats: Energize vs focus score correlation
- Energize stats fetched only when `app.methodology == MethodologyMakeTime`
- `renderEnergizeInsights()` displays activity / sessions / avg-focus table
- Results sorted by avg_focus DESC from SQL

---

All changes: `gofmt -w .`, `golangci-lint run ./...` (0 issues), `go test ./...` (all pass).
